### PR TITLE
Removes FACTER_GEM _VERSION="~> 1.6.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5.0"
   - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
-  - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
   allow_failures:
   - rvm: 2.4.1


### PR DESCRIPTION
Removes this test from test matrix as it will always fail: the module requires facter 1.7+ as stated in line 17 of `puppet-openvmtools/manifests/params.pp` file: `if $::operatingsystemmajrelease { # facter 1.7+`

Related to PR#11.