### PR TITLE
Fix regex_replace error on puppet 5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,7 +128,7 @@ class openvmtools (
 
       if $uninstall_vmware_tools {
         if $facts['vmware_uninstaller'] =~ Stdlib::Unixpath {
-          $vmware_lib = $facts['vmware_uninstaller'].regex_replace(
+          $vmware_lib = regsubst( $facts['vmware_uninstaller'],
             'bin/vmware-uninstall-tools.pl',
             'lib/vmware-tools'
           )


### PR DESCRIPTION
#### Pull Request (PR) description

When running this module on puppet v5.5 master with puppet v5.5 agents and I get the following error:

```
Error: Could not retrieve catalog from remote server: 
Error 500 on SERVER: Server Error: Evaluation Error: Unknown function: 'regex_replace'.
(file: /etc/puppetlabs/code/environments/production/modules/openvmtools/manifests/init.pp, line: 132, column: 67) on node node003.example.lan
```

I couldn't figure out what was the problem, cause I didn't have this error on all nodes, but it's still better to use built-in function `regsubst`.

I tested this with `stdlib` versions `6.1.0`, `6.3.0` and `6.5.0`.