### PR TITLE
Autodetect supported instead of using Hiera

### DIFF
--- a/data/Debian.Debian.10.yaml
+++ b/data/Debian.Debian.10.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Debian.Debian.7.yaml
+++ b/data/Debian.Debian.7.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Debian.Debian.8.yaml
+++ b/data/Debian.Debian.8.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Debian.Debian.9.yaml
+++ b/data/Debian.Debian.9.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Debian.Ubuntu.14.04.yaml
+++ b/data/Debian.Ubuntu.14.04.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Debian.Ubuntu.16.04.yaml
+++ b/data/Debian.Ubuntu.16.04.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Debian.Ubuntu.18.04.yaml
+++ b/data/Debian.Ubuntu.18.04.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/FreeBSD.FreeBSD.10.yaml
+++ b/data/FreeBSD.FreeBSD.10.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/FreeBSD.FreeBSD.11.yaml
+++ b/data/FreeBSD.FreeBSD.11.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/FreeBSD.FreeBSD.12.yaml
+++ b/data/FreeBSD.FreeBSD.12.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.CentOS.6.yaml
+++ b/data/RedHat.CentOS.6.yaml
@@ -1,4 +1,3 @@
 ---
 
 openvmtools::manage_epel: true
-openvmtools::supported: true

--- a/data/RedHat.CentOS.7.yaml
+++ b/data/RedHat.CentOS.7.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.CentOS.8.yaml
+++ b/data/RedHat.CentOS.8.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.Fedora.19.yaml
+++ b/data/RedHat.Fedora.19.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.Fedora.20.yaml
+++ b/data/RedHat.Fedora.20.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.Fedora.21.yaml
+++ b/data/RedHat.Fedora.21.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.Fedora.22.yaml
+++ b/data/RedHat.Fedora.22.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.Fedora.23.yaml
+++ b/data/RedHat.Fedora.23.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.Fedora.24.yaml
+++ b/data/RedHat.Fedora.24.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.Fedora.25.yaml
+++ b/data/RedHat.Fedora.25.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.OracleLinux.6.yaml
+++ b/data/RedHat.OracleLinux.6.yaml
@@ -1,4 +1,3 @@
 ---
 
 openvmtools::manage_epel: true
-openvmtools::supported: true

--- a/data/RedHat.OracleLinux.7.yaml
+++ b/data/RedHat.OracleLinux.7.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.OracleLinux.8.yaml
+++ b/data/RedHat.OracleLinux.8.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.RedHat.6.yaml
+++ b/data/RedHat.RedHat.6.yaml
@@ -1,4 +1,3 @@
 ---
 
 openvmtools::manage_epel: true
-openvmtools::supported: true

--- a/data/RedHat.RedHat.7.yaml
+++ b/data/RedHat.RedHat.7.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/RedHat.RedHat.8.yaml
+++ b/data/RedHat.RedHat.8.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.OpenSUSE.11.yaml
+++ b/data/Suse.OpenSUSE.11.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.OpenSUSE.12.yaml
+++ b/data/Suse.OpenSUSE.12.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.OpenSUSE.13.yaml
+++ b/data/Suse.OpenSUSE.13.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.OpenSUSE.15.yaml
+++ b/data/Suse.OpenSUSE.15.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.OpenSUSE.42.yaml
+++ b/data/Suse.OpenSUSE.42.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.SLES.12.yaml
+++ b/data/Suse.SLES.12.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.SLES.13.yaml
+++ b/data/Suse.SLES.13.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.SLES.14.yaml
+++ b/data/Suse.SLES.14.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/data/Suse.SLES.15.yaml
+++ b/data/Suse.SLES.15.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::supported: true

--- a/functions/supported.pp
+++ b/functions/supported.pp
@@ -1,0 +1,18 @@
+# @summary Returns whether the currently loaded OS is supported by the module
+#
+# This function uses the current facts to check if the current Operating System
+# and its release or major release is supported.
+#
+# @param mod
+#  The module name to check.
+#
+# @return Whether the current OS is supported for the given module
+#
+# @example Using the Puppet built in global $module_name
+#   openvmtools::supported($module_name)
+function openvmtools::supported(String[1] $mod) >> Boolean {
+  $metadata = load_module_metadata($mod)
+  $metadata['operatingsystem_support'].any |$os| {
+    $os['operatingsystem'] == $facts['os']['name'] and $facts['os']['release']['major'] in $os['operatingsystemrelease']
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,12 +96,12 @@ class openvmtools (
   Boolean                             $service_hasstatus         = true,
   Variant[String[1],Array[String[1]]] $service_name              = ['vgauthd', 'vmtoolsd'],
   Optional[String[1]]                 $service_pattern           = undef,
-  Boolean                             $supported                 = false,
+  Optional[Boolean]                   $supported                 = undef,
   Boolean                             $uninstall_vmware_tools    = false,
   Boolean                             $with_desktop              = false,
 ) {
   if $facts['virtual'] == 'vmware' {
-    if $supported {
+    if pick($supported, openvmtools::supported($module_name)) {
       if $ensure == 'present' {
         $package_ensure = $autoupgrade ? {
           true    => 'latest',

--- a/spec/functions/supported_spec.rb
+++ b/spec/functions/supported_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'openvmtools::supported' do
+  context 'On Debian 10' do
+    let(:facts) do
+      {
+        os: {
+          name: 'Debian',
+          release: {
+            major: '10',
+          }
+        }
+      }
+    end
+
+    it 'returns true' do
+      is_expected.to run.with_params('openvmtools').and_return(true)
+    end
+  end
+end


### PR DESCRIPTION
Previously it (ab)used Hiera to set the supported versions. This now uses metadata.json and facts to do the same. The parameter is kept in to override this. It is turned into undef to allow pick() and signal that the value is determined later.