### PR TITLE
Repair service management in Ubuntu 14.04

### DIFF
--- a/data/Debian.Ubuntu.14.04.yaml
+++ b/data/Debian.Ubuntu.14.04.yaml
@@ -1,0 +1,3 @@
+---
+
+openvmtools::service_pattern: 'vmtoolsd'


### PR DESCRIPTION
#### Pull Request (PR) description
This repairs Ubuntu 14.04, which is broken in the current git master state. The init-v script has no "status" command and is not idempotent, so puppet goes crazy and reintroduces bug #1 
In 2015 this was repaired by https://github.com/voxpupuli/puppet-openvmtools/commit/21cd8c1cb2ab1f1c3a242b2ded4dcee5823dd697 (introducing service_pattern and setting it to vmtoolsd).
However it was changed again with https://github.com/voxpupuli/puppet-openvmtools/commit/4e08426b08c34199e948ace474b9a8a09dc30ee9 (setting service_pattern to undef).
I don't know why Ubuntu 14 worked with a git state some commits earlier (because we used that), but i don't want to waste energy searching for it.
This PR reestablishes the service_pattern for Ubuntu 14.04. Newer ones rely on systemd for status. 

#### This Pull Request (PR) fixes the following issues
#1 (was already fixed but came back alive)
