### PR TITLE
add rhel9 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,8 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description

Add RHEL 9 to metadata.json so it is recognised as a supported OS (requires appstream repos; this is also the case for RHEL 8)

#### This Pull Request (PR) fixes the following issues

`Your operating system RedHat is unsupported and will not have the Open Virtual Machine Tools installed.` (as `openvmtools::supported()` uses `metadata.json` to determine supported platforms)
