### PR TITLE
Add AlmaLinux 8 and Centos/Rocky/OracleLinux/AlmaLinux 9 to supported OS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -66,7 +67,8 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -80,7 +82,15 @@
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Add AlmaLinux 8 and Centos/Rocky/OracleLinux/AlmaLinux 9 to supported OS

#### This Pull Request (PR) fixes the following issues
Fixes #56 
