### PR TITLE
Drop EL6 Hiera data

### DIFF
--- a/data/RedHat.CentOS.6.yaml
+++ b/data/RedHat.CentOS.6.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::manage_epel: true

--- a/data/RedHat.OracleLinux.6.yaml
+++ b/data/RedHat.OracleLinux.6.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::manage_epel: true

--- a/data/RedHat.RedHat.6.yaml
+++ b/data/RedHat.RedHat.6.yaml
@@ -1,3 +1,0 @@
----
-
-openvmtools::manage_epel: true


### PR DESCRIPTION
This only turns on EPEL, but EPEL 6 is dead. The module also dropped EL6 support already.

Fixes: d92b157cb92b6de96405c348ac86a20fa54d2835 ("modulesync")