### PR TITLE
Drop puppetlabs/yumrepo_core from dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,10 +8,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 2.3.0 < 10.0.0"
-    },
-    {
-      "name": "puppetlabs/yumrepo_core",
-      "version_requirement": ">=1.0.0 <2.0.0"
     }
   ],
   "issues_url": "https://github.com/voxpupuli/puppet-openvmtools/issues",


### PR DESCRIPTION
Yumrepo_core should always be present on systems, therefore the dependency is not needed.